### PR TITLE
解决首字母大写无法触发临时英文状态

### DIFF
--- a/src/rime/gear/ascii_composer.cc
+++ b/src/rime/gear/ascii_composer.cc
@@ -131,7 +131,7 @@ ProcessResult AsciiComposer::ProcessKeyEvent(const KeyEvent& key_event) {
 	  && ch >= 0x20 && ch < 0x80 && isupper(ch) && auto_inline) {
 	  if (!key_event.release()) {
 		  ctx->PushInput(ch);
-		  ToggleAsciiModeWithKey(XK_Shift_L);
+		  SwitchAsciiMode(true, kAsciiModeSwitchInline);
 		  return kAccepted;
 	  }
   }


### PR DESCRIPTION
这里写死了一个`XK_Shift_L`，当我把`ascii_composer/switch_key/Shift_L`设为`noop`时，首字母大写无法触发临时英文状态。
修复的办法是将`ToggleAsciiModeWithKey(XK_Shift_L)`改为`SwitchAsciiMode(true, kAsciiModeSwitchInline)`